### PR TITLE
Add PageUp/PageDown Navigation for Container List Overflow

### DIFF
--- a/dockedup/__init__.py
+++ b/dockedup/__init__.py
@@ -3,7 +3,7 @@ DockedUp - htop for your Docker Compose stack.
 An interactive, real-time monitor for Docker containers and Compose projects.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "Anil Raj Rimal"
 __email__ = "anilrajrimal@gmail.com"
 __description__ = "Interactive Docker Compose stack monitor - htop for Docker"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dockedup"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
     {name = "Anil Raj Rimal", email = "anilrajrimal@gmail.com"},
 ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix

This PR addresses an issue where, in smaller terminal windows, not all containers within a project are visible due to the lack of terminal scroll support.

### What's Added
- Implemented **PageUp / PageDown** support to shift the container list view one project at a time.
- Allows navigation through projects with many containers even in constrained terminal viewports.

### Technical Note
Due to limitations in the `typer` library, true terminal scrolling isn't supported. This workaround provides a functional way to view hidden containers without requiring the user to resize the terminal window.

### How to Test
1. Run a `docker-compose` project with 5–10 containers.
2. Start `dockedup` in a small terminal window.
3. Use `PageUp` / `PageDown` keys to shift the container list and view all entries.

### 🔒 Related Issue
Closes #14  
